### PR TITLE
Allow dynamic changes of extraData

### DIFF
--- a/src/dmuploader.js
+++ b/src/dmuploader.js
@@ -230,6 +230,7 @@
 
     // Append extra Form Data
     $.each(widget.settings.extraData, function(exKey, exVal){
+      if (typeof exVal == 'function') { exVal = exVal(); }
       fd.append(exKey, exVal);
     });
 


### PR DESCRIPTION
As it stands it's impossible to send e.g. the value of a checkbox along
with the files - my example was to have a 'allow file replacement' box,
but this only works if you can examine the checkbox as the file is
dropped. My solution I think is more general than Fazioli's by allowing
the values in the extraData to be functions, and if they are to call
them as the formData is created and use the return values for the value
of the parameter.
