### PR TITLE
Timeout value override

### DIFF
--- a/src/js/jquery.dm-uploader.js
+++ b/src/js/jquery.dm-uploader.js
@@ -126,6 +126,7 @@
       cache: false,
       contentType: false,
       processData: false,
+      timeout:0,
       forceSync: false,
       xhr: function() { return file.getXhr(); },
       success: function(data) { file.onSuccess(data); },


### PR DESCRIPTION
Override the timeout value in case it was set using $.ajaxSetup from outside.

In my WebAPP, i use Jquery for XHR communications, and have setup a timeout value. This timeout value influences DMUploader, which it shouldn't. 
Looking at Jquery Documentation, We see the default value is 0. 
`timeout
Type: Number
Set a timeout (in milliseconds) for the request. A value of 0 means there will be no timeout. This will override any global timeout set with $.ajaxSetup(). The timeout period starts at the point the $.ajax call is made; if several other requests are in progress and the browser has no connections available, it is possible for a request to time out before it can be sent. In jQuery 1.4.x and below, the XMLHttpRequest object will be in an invalid state if the request times out; accessing any object members may throw an exception. In Firefox 3.0+ only, script and JSONP requests cannot be cancelled by a timeout; the script will run even if it arrives after the timeout period.`

` $.ajaxSetup({
        timeout: 5000,
        error: function(event, request, settings){
        errorMessage(event.responseText);
        }
    });`